### PR TITLE
Fixed bug where potions named (unfinished) were not removed without Cleaning Herbs rule

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -3351,7 +3351,7 @@ let calcChallengesWork = function(chunks, baseChunkData, oldTempItemSkill) {
                     return true;
                 }
             });
-			if (!rules['Cleaning Herbs'] && (name.includes('Clean a') || name.includes('(unf)')) && skill === 'Herblore' && chunkInfo['challenges'][skill][name]['Level'] > 1) {
+			if (!rules['Cleaning Herbs'] && (name.includes('Clean a') || (name.includes('Mix a') && ( name.includes('(unfinished)') || name.includes('(unf)')))) && skill === 'Herblore' && chunkInfo['challenges'][skill][name]['Level'] > 1) {
                 chunkInfo['challenges'][skill][name]['NeverShow'] = true;
             }
             if (wrongThings.length > 0) {


### PR DESCRIPTION
Changed the code to accommodate the change in the naming of (unf) to (unfinished) of some potions, made it more restrictive by requiring the beginning to be "Mix a" just in case of any confusion and should still work with any special kind of potion that uses (unf)